### PR TITLE
ブログ一覧ページのカードリンクを改善

### DIFF
--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -30,28 +30,29 @@ export default createRoute(async (c) => {
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {posts.map(post => (
-          <article class="bg-white dark:bg-purple-900/20 rounded-lg shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all duration-200 overflow-hidden">
-            <a href={`/blog/${post.slug}`} class="block">
-              {post.heroImage && (
-                <img 
-                  src={post.heroImage} 
-                  alt={post.title}
-                  class="w-full h-48 object-cover"
-                />
+          <article class="bg-white dark:bg-purple-900/20 rounded-lg shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all duration-200 overflow-hidden relative">
+            <a href={`/blog/${post.slug}`} class="absolute inset-0 z-0"></a>
+            {post.heroImage && (
+              <img 
+                src={post.heroImage} 
+                alt={post.title}
+                class="w-full h-48 object-cover"
+              />
+            )}
+            <div class="p-6">
+              <h2 class="text-xl font-bold mb-2 text-gray-900 dark:text-gray-100">{post.title}</h2>
+              <p class="text-gray-600 dark:text-gray-400 mb-3 text-sm line-clamp-3">{post.description}</p>
+            </div>
+            <div class="px-6 pb-6">
+              <time class="text-xs text-gray-500 dark:text-gray-500">{post.pubDate}</time>
+              {post.tags && (
+                <div class="flex gap-1 flex-wrap mt-3">
+                  {post.tags.slice(0, 3).map((tag: string) => (
+                    <a href={`/blog/tag/${tag}`} class="relative z-10 px-2 py-1 bg-gray-100 dark:bg-purple-900/30 rounded text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-purple-900/40 transition-colors">{tag}</a>
+                  ))}
+                </div>
               )}
-              <div class="p-6">
-                <h2 class="text-xl font-bold mb-2 text-gray-900 dark:text-gray-100">{post.title}</h2>
-                <p class="text-gray-600 dark:text-gray-400 mb-3 text-sm line-clamp-3">{post.description}</p>
-                <time class="text-xs text-gray-500 dark:text-gray-500">{post.pubDate}</time>
-                {post.tags && (
-                  <div class="flex gap-1 flex-wrap mt-3">
-                    {post.tags.slice(0, 3).map((tag: string) => (
-                      <a href={`/blog/tag/${tag}`} class="px-2 py-1 bg-gray-100 dark:bg-purple-900/30 rounded text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-purple-900/40 transition-colors">{tag}</a>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </a>
+            </div>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## 概要
ブログ一覧ページのリンクカードのクリック範囲とタグリンクの機能を改善しました。

## 変更内容
- **カード全体をクリック可能に**: メインリンクを `absolute inset-0` でカード全体をカバーするオーバーレイに変更
- **タグリンクの優先度設定**: タグを `z-10` でメインリンクより上に配置してクリック優先度を設定
- **レイアウトの最適化**: absolute positioning を使用してリンクの階層を適切に管理

## 修正された問題
- ✅ 日付から下の部分（タグエリア）がクリックできない問題
- ✅ タグのリンクが機能しない問題  
- ✅ カード全体がリンクとして機能していない問題

## 動作確認
- カード全体がブログ記事へのリンクとして機能
- タグ部分をクリックした場合はタグページに遷移
- タグ以外の部分をクリックした場合はブログ記事に遷移

Closes #11