### PR TITLE
chore: integrate project documentation into README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,25 +1,8 @@
 # yumenomatayume.net Blog Management Agents
 
-## Project Overview
+## Project Documentation
 
-**Tech Stack:**
-- HonoX (Hono-based meta-framework)
-- Cloudflare Pages (Hosting)
-- Tailwind CSS v4 (Styling)
-- MDX (Markdown + JSX)
-- Cloudinary (Image management)
-- Prism.js (Syntax highlighting)
-
-**Project Structure:**
-```
-app/
-├── routes/              # ルーティング
-├── content/blog/        # MDX 記事
-├── components/          # React コンポーネント
-└── style.css           # グローバルスタイル
-public/images/          # 画像ファイル
-scripts/                # ユーティリティスクリプト
-```
+For comprehensive details about the project's tech stack, structure, setup, development workflow, deployment, and scripts, please refer to README.md.
 
 ## Content Management Agents
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ HonoX + Cloudflare Pages で構築されたブログサイト
 - [Tailwind CSS](https://tailwindcss.com/) - スタイリング
 - [MDX](https://mdxjs.com/) - Markdown + JSX
 - [Cloudinary](https://cloudinary.com/) - 画像管理
+- [Prism.js](https://prismjs.com/) - シンタックスハイライト
 
 ## Features
 
@@ -87,7 +88,7 @@ bun run upload
 .
 ├── app/
 │   ├── routes/          # ルーティング
-│   ├── content/         # MDX 記事
+│   ├── content/blog/         # MDX 記事
 │   ├── components/      # React コンポーネント
 │   ├── style.css        # グローバルスタイル
 │   ├── client.ts        # クライアントエントリー


### PR DESCRIPTION
## Changes
- **README.md**
  - Add Prism.js to Tech Stack
  - Update project structure: `content/` → `content/blog/`
- **CLAUDE.md (via .github/copilot-instructions.md)**
  - Remove duplicated Tech Stack and Project Structure sections
  - Add reference to README.md for project details

## Rationale
Consolidate project documentation in README.md (human-facing) and reference it from CLAUDE.md (AI-facing) to avoid duplication and maintain clear separation of concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)