### PR TITLE
docs: organize agent docs and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,143 +1,21 @@
-# yumenomatayume.net Blog Management Agents
+## Project Overview
 
-ブログ記事作成を支援するエージェントの定義と運用ガイドラインです。
+yumenomatayume.net のブログ管理リポジトリ。
+HonoX + Cloudflare Workers で構築されたブログサイトです。
 
-詳細なプロジェクト設定については [README.md](./README.md) を参照してください。
+人向けの概要、セットアップ、コマンド、ディレクトリ構成は [README.md](./README.md) を参照してください。
 
----
+## Agent Guidelines
 
-## Content Management Agents
+- README と重複する一般説明は AGENTS.md に追加しない。
+- 作業前に関連する `skills/*/SKILL.md` を確認する。
+- ブログ記事は `app/content/blog/`、記事画像は `public/images/` を使用する。
+- 実装後は変更範囲に応じて `bun run build` などで検証する。
 
-### 1. Linear Issue to Blog Article
+## Skills
 
-**トリガー:** `linear の [ISSUE-ID] からブログ記事を書いて` または `create blog from linear [ISSUE-ID]`
+Content management workflows are managed as repository skills:
 
-**Workflow:**
-1. Linear issue の詳細を取得
-2. issue 内の画像を `public/images/` にダウンロード
-3. 既存記事の形式に合わせて `app/content/blog/` にブログ記事を作成
-4. 文章を校正
-5. 画像パスを記事内で適切に参照
-6. Linear の `gitBranchName` を使用してブランチを作成
-7. 記事ファイルをコミット（メッセージ：`feat: [記事タイトル] の記事を追加`）
-8. PR を作成（ユーザーが記事内容を確認後にマージ）
-9. マージは `gh pr merge -md --auto` コマンドを実行する
-10. **マージ完了後、Linear issue にコメントで公開報告（PR と記事 URL を含む）**
-
-**Settings:**
-| 項目 | 値 |
-|------|-----|
-| Blog directory | `app/content/blog/` |
-| Image directory | `public/images/` |
-| Article format | MDX with frontmatter |
-| File naming | `{issue-title-kebab-case}.md` |
-| Image naming | `{descriptive-name}.png` |
-
----
-
-### 2. Article Proofreading Agent
-
-**トリガー:** `記事を校正して` または `全記事の校正をして`
-
-**校正基準:**
-- タイトル末尾に絵文字追加（統一感のため）
-- ですます調への統一
-- 絵文字を適度に使用（親しみやすさ向上）
-- 読みやすい文章構造
-- description の追加（SEO 向上）
-
----
-
-### 3. UI/UX Enhancement Agent
-
-**トリガー:** `UI を改善して` または `デザインを変更して`
-
-**Recent Implementations:**
-- タグ一覧の折りたたみ機能 (`details`要素使用)
-- ダークモード対応
-- レスポンシブデザイン
-- 記事カードのホバーエフェクト
-
-**CSS Guidelines:**
-- Tailwind CSS v4 使用
-- `@theme` ブロックにはカスタムプロパティのみ
-- 通常の CSS ルールは `@theme` ブロック外に記述
-
----
-
-## Article Format
-
-```markdown
----
-title: "記事タイトル 🎯"
-description: "記事の説明文"
-pubDate: "YYYY-MM-DD"
-tags: ["tag1", "tag2"]
-heroImage: "https://cloudinary-url" # optional
----
-
-記事内容...
-```
-
----
-
-## Writing Style
-
-- ですます調で統一
-- 絵文字を適度に使用
-- 技術記事は具体例とコード例を含める
-- 読者にとって分かりやすい構造
-
----
-
-## Tag Management
-
-- タグ一覧はデフォルト非表示 (`details`要素)
-- 記事カードでは最初の 3 つのタグのみ表示
-- タグページでの記事フィルタリング対応
-
----
-
-## Development Workflow
-
-### Branch Naming Convention
-
-Feature branches: `issue/{issue-number}`
-
-```
-Example: issue/1, issue/2, issue/3
-```
-
-### Git Workflow
-
-1. Create branch: `git checkout -b issue/1`
-2. Commit with reference: `git commit -m "feat: 機能名 (#1)"`
-3. Push and create PR: `gh pr create --title "機能名" --body "Closes #1"`
-4. PR merge automatically closes the issue
-
-### Commit Message Format
-
-| 種類 | フォーマット |
-|------|-------------|
-| 新機能 | `feat: 新機能 (#issue-number)` |
-| バグ修正 | `fix: バグ修正 (#issue-number)` |
-| ドキュメント | `docs: ドキュメント更新 (#issue-number)` |
-| スタイル調整 | `style: スタイル調整 (#issue-number)` |
-
-### Commit Best Practices
-
-- メッセージは英語で記述
-- **機能ごとに細かくコミット** - 1 つのコミットは 1 つの機能や修正に集中
-- 複数の変更がある場合は `git reset` で分割してコミット
-  - 例：SearchBox 作成、Header 統合、CSS 追加を別々のコミットに分ける
-- コミットメッセージは変更内容を具体的に記述
-- **記事追加時は簡潔な 1 行メッセージ** - プライベートツール（Linear 等）の詳細情報は不要
-- 記事追加の場合は `"Add [article-topic] article"` 形式で十分（内容は記事を見れば分かるため）
-
----
-
-## Contact & Links
-
-- **Email:** [yumenomatayume@yumenomatayume.net](mailto:yumenomatayume@yumenomatayume.net)
-- **GitHub:** [@ymmmtym](https://github.com/ymmmtym)
-- **Blog:** [https://yumenomatayume.net](https://yumenomatayume.net)
+- `skills/linear-issue-blog-article/SKILL.md`
+- `skills/article-proofreading/SKILL.md`
+- `skills/ui-ux-enhancement/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # yumenomatayume.net
 
-HonoX + Cloudflare Pages で構築されたブログサイト
+HonoX + Cloudflare Workers で構築されたブログサイトです。
+記事は MDX で管理し、画像は Cloudinary で最適化します。
+
+エージェント向けの作業ルールは [AGENTS.md](./AGENTS.md) を参照してください。
 
 ## Tech Stack
 
 - [HonoX](https://github.com/honojs/honox) - Hono ベースのメタフレームワーク
-- [Cloudflare Workers](https://pages.cloudflare.com/) - ホスティング
+- [Cloudflare Workers](https://workers.cloudflare.com/) - ホスティング
 - [Tailwind CSS](https://tailwindcss.com/) - スタイリング
 - [MDX](https://mdxjs.com/) - Markdown + JSX
 - [Cloudinary](https://cloudinary.com/) - 画像管理
@@ -71,13 +74,14 @@ bun run deploy
 
 ## Image Upload
 
-`public/images` に配置された画像を Cloudinary にアップロードし、記事内のリンクを自動で置き換えます:
+`public/images/` に配置された画像を Cloudinary にアップロードし、記事内のリンクを自動で置き換えます。
 
 ```bash
 bun run upload
 ```
 
 処理内容:
+
 1. `public/images` 内の画像を Cloudinary にアップロード
 2. 最適化された URL を生成 (`f_auto,q_auto`)
 3. `app/content` 内の MDX ファイルで参照されている画像パスを Cloudinary URL に置き換え
@@ -88,8 +92,9 @@ bun run upload
 .
 ├── app/
 │   ├── routes/          # ルーティング
-│   ├── content/blog/         # MDX 記事
+│   ├── content/blog/    # MDX 記事
 │   ├── components/      # React コンポーネント
+│   ├── utils/           # ユーティリティ
 │   ├── style.css        # グローバルスタイル
 │   ├── client.ts        # クライアントエントリー
 │   └── server.ts        # サーバーエントリー
@@ -98,6 +103,7 @@ bun run upload
 ├── scripts/             # ユーティリティスクリプト
 │   ├── upload-and-replace.ts
 │   └── upload-single.ts
+├── skills/              # Codex 用スキル定義
 └── dist/                # ビルド出力
 ```
 
@@ -106,7 +112,7 @@ bun run upload
 - `dev` - 開発サーバー起動
 - `build` - プロダクションビルド
 - `preview` - ローカルプレビュー (Wrangler)
-- `deploy` - Cloudflare Pages にデプロイ
+- `deploy` - Cloudflare Workers にデプロイ
 - `upload` - 画像を Cloudinary にアップロード
 
 ## License

--- a/skills/article-proofreading/SKILL.md
+++ b/skills/article-proofreading/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: article-proofreading
+description: Use when proofreading yumenomatayume.net blog articles, including prompts like "記事を校正して" or "全記事の校正をして".
+---
+
+# Article Proofreading
+
+## Criteria
+
+- タイトル末尾に絵文字を追加し、記事一覧での統一感を保つ。
+- 文体はですます調に統一する。
+- 親しみやすさを上げるため、絵文字を適度に使用する。
+- 見出し、段落、箇条書きを整理して読みやすい文章構造にする。
+- SEO のため `description` がない記事には追加する。
+
+## Article Format
+
+```markdown
+---
+title: "記事タイトル 🎯"
+description: "記事の説明文"
+pubDate: "YYYY-MM-DD"
+tags: ["tag1", "tag2"]
+heroImage: "https://cloudinary-url" # optional
+---
+
+記事内容...
+```

--- a/skills/linear-issue-blog-article/SKILL.md
+++ b/skills/linear-issue-blog-article/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: linear-issue-blog-article
+description: Use when creating a yumenomatayume.net blog article from a Linear issue, including prompts like "linear の [ISSUE-ID] からブログ記事を書いて" or "create blog from linear [ISSUE-ID]".
+---
+
+# Linear Issue to Blog Article
+
+## Workflow
+
+1. Linear issue の詳細を取得する。
+2. issue 内の画像を `public/images/` にダウンロードする。
+3. 既存記事の形式に合わせて `app/content/blog/` に MDX 記事を作成する。
+4. 文章を校正する。
+5. 画像パスを記事内で適切に参照する。
+6. Linear の `gitBranchName` を使用してブランチを作成する。
+7. 記事ファイルをコミットする。コミットメッセージは `feat: [記事タイトル] の記事を追加` とする。
+8. PR を作成する。ユーザーが記事内容を確認した後にマージする。
+9. マージは `gh pr merge -md --auto` を実行する。
+10. マージ完了後、Linear issue に PR と記事 URL を含む公開報告コメントを追加する。
+
+## Settings
+
+| 項目 | 値 |
+| ---- | ---- |
+| Blog directory | `app/content/blog/` |
+| Image directory | `public/images/` |
+| Article format | MDX with frontmatter |
+| File naming | `{issue-title-kebab-case}.md` |
+| Image naming | `{descriptive-name}.png` |
+
+## Article Format
+
+```markdown
+---
+title: "記事タイトル 🎯"
+description: "記事の説明文"
+pubDate: "YYYY-MM-DD"
+tags: ["tag1", "tag2"]
+heroImage: "https://cloudinary-url" # optional
+---
+
+記事内容...
+```

--- a/skills/ui-ux-enhancement/SKILL.md
+++ b/skills/ui-ux-enhancement/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ui-ux-enhancement
+description: Use when improving yumenomatayume.net UI or design, including prompts like "UI を改善して" or "デザインを変更して".
+---
+
+# UI/UX Enhancement
+
+## Recent Implementations
+
+- タグ一覧の折りたたみ機能は `details` 要素で実装済み。
+- ダークモード対応済み。
+- レスポンシブデザイン対応済み。
+- 記事カードのホバーエフェクト実装済み。
+
+## Project Context
+
+- Blog content lives in `app/content/blog/`.
+- Article images live in `public/images/`.
+- Application source lives in `app/`.
+- Run `bun run build` before handoff when practical.


### PR DESCRIPTION
## Summary
- Move content management agent workflows into repository skills
- Keep AGENTS.md focused on agent-specific guidance
- Update README.md for human-facing project documentation

## Verification
- Documentation-only change; build not run