### PR TITLE
fix: grant write permissions to opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Update opencode workflow permissions to allow comment posting
- Change `pull-requests: read` and `issues: read` to `write`
- Fix `opencode-agent[bot] does not have write permissions` error

## Changes
- `.github/workflows/opencode.yml`: Updated permissions for pull-requests and issues from `read` to `write`