### PR TITLE
fix: grant write permissions to opencode-review workflow for PR comments

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Fix opencode-review workflow permissions so the opencode-agent bot can post review comments on PRs
- Changed `pull-requests: read` to `pull-requests: write` in `.github/workflows/opencode-review.yml`

## Background

The opencode-review workflow was failing with `403 Resource not accessible by integration` because the GITHUB_TOKEN lacked write permissions to post comments on pull requests.